### PR TITLE
Add the variaus FragmentLayout containers to Home

### DIFF
--- a/src/main/java/com/nof/vamathcalculator/CompensationSummaryFragment.java
+++ b/src/main/java/com/nof/vamathcalculator/CompensationSummaryFragment.java
@@ -1,0 +1,62 @@
+package com.nof.vamathcalculator;
+
+import android.os.Bundle;
+import android.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link CompensationSummaryFragment#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class CompensationSummaryFragment extends Fragment {
+
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+    public CompensationSummaryFragment() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment CompensationSummaryFragment.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static CompensationSummaryFragment newInstance(String param1, String param2) {
+        CompensationSummaryFragment fragment = new CompensationSummaryFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_compensation_summary, container, false);
+    }
+}

--- a/src/main/java/com/nof/vamathcalculator/DependencySummaryFragment.java
+++ b/src/main/java/com/nof/vamathcalculator/DependencySummaryFragment.java
@@ -1,0 +1,62 @@
+package com.nof.vamathcalculator;
+
+import android.os.Bundle;
+import android.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link DependencySummaryFragment#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class DependencySummaryFragment extends Fragment {
+
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+    public DependencySummaryFragment() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment DependecySummaryFragment.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static DependencySummaryFragment newInstance(String param1, String param2) {
+        DependencySummaryFragment fragment = new DependencySummaryFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_dependecy_summary, container, false);
+    }
+}

--- a/src/main/java/com/nof/vamathcalculator/DisabilitySummaryScrollFragment.java
+++ b/src/main/java/com/nof/vamathcalculator/DisabilitySummaryScrollFragment.java
@@ -1,0 +1,62 @@
+package com.nof.vamathcalculator;
+
+import android.os.Bundle;
+import android.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link DisabilitySummaryScrollFragment#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class DisabilitySummaryScrollFragment extends Fragment {
+
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+    public DisabilitySummaryScrollFragment() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment DisabilitySummaryScrollFragment.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static DisabilitySummaryScrollFragment newInstance(String param1, String param2) {
+        DisabilitySummaryScrollFragment fragment = new DisabilitySummaryScrollFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_disability_summary_scroll, container, false);
+    }
+}

--- a/src/main/java/com/nof/vamathcalculator/HomeScrollingFragment.java
+++ b/src/main/java/com/nof/vamathcalculator/HomeScrollingFragment.java
@@ -1,6 +1,7 @@
 package com.nof.vamathcalculator;
 
 import android.annotation.SuppressLint;
+import android.app.FragmentTransaction;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,6 +21,32 @@ public class HomeScrollingFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater,
                              @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
+
+        /**
+         * Add the DependencyStatus child fragment to the nested FragmentLayout within the
+         * fragment_home_scrolling.xml file.
+         */
+        FragmentTransaction ft = getChildFragmentManager().beginTransaction();
+
+        DependencySummaryFragment depend_frag = new DependencySummaryFragment();
+        ft.replace(R.id.home_sticky_content, depend_frag);
+        ft.addToBackStack(null);
+
+
+        DisabilitySummaryScrollFragment ratings_frag = new DisabilitySummaryScrollFragment();
+        ft.replace(R.id.home_scroll_content, ratings_frag);
+        ft.addToBackStack(null);
+
+        CompensationSummaryFragment compensation_frag = new CompensationSummaryFragment();
+        ft.replace(R.id.home_compensation_content, compensation_frag);
+        ft.addToBackStack(null);
+
+        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
+        ft.commit();
+
+        /**
+         * Inflate the fragment_home_scrolling.xml layout file
+         */
         return inflater.inflate(R.layout.fragment_home_scrolling, container, false);
     }
 }

--- a/src/main/java/com/nof/vamathcalculator/MainActivity.java
+++ b/src/main/java/com/nof/vamathcalculator/MainActivity.java
@@ -6,7 +6,6 @@
 package com.nof.vamathcalculator;
 
 import android.app.Activity;
-import android.app.FragmentManager;
 import android.content.res.Configuration;
 import android.os.Bundle;
 
@@ -28,6 +27,9 @@ import android.support.v7.app.ActionBarDrawerToggle;
 
 public class MainActivity extends Activity {
 
+    /**
+     * Use user-friendly enumerations for that relate fragment and nav menu position.
+     */
     private final int HOME_SCREEN = 0;
     private final int TEST_FRAG = 1;
     //private final int ABOUT_FRAG = 1;
@@ -64,7 +66,7 @@ public class MainActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);  // lifecyle methods require calling the base constructor
+        super.onCreate(savedInstanceState);  // lifecycle methods require calling the base constructor
 
         /**
          * Load the contents of the activity_main.xml file
@@ -100,7 +102,7 @@ public class MainActivity extends Activity {
         ));
 
         /**
-         * This attaches the custom drawer onClick listener to the ListView with the drawer layout.
+         * This attaches the custom drawer onClick listener to the ListView within the drawer layout.
          */
         drawer_list.setOnItemClickListener(new DrawerItemClickListener());
 
@@ -154,7 +156,8 @@ public class MainActivity extends Activity {
 
         /**
          * The fragment onBackStackChanged listener is used to update the title when
-         * the back button is pressed.
+         * the back button is pressed. It is also used to highlight the correct item int the
+         * navigation menu.
          */
         getFragmentManager().addOnBackStackChangedListener(
                 new FragmentManager.OnBackStackChangedListener() {

--- a/src/main/res/layout/fragment_compensation_summary.xml
+++ b/src/main/res/layout/fragment_compensation_summary.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".CompensationSummaryFragment">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/text_margin"
+        android:text="@string/home_compensation_content_placeholder_text" />
+
+</FrameLayout>

--- a/src/main/res/layout/fragment_dependecy_summary.xml
+++ b/src/main/res/layout/fragment_dependecy_summary.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DependencySummaryFragment">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/text_margin"
+        android:text="@string/home_sticky_content_placeholder_text" />
+
+</FrameLayout>

--- a/src/main/res/layout/fragment_disability_summary_scroll.xml
+++ b/src/main/res/layout/fragment_disability_summary_scroll.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DisabilitySummaryScrollFragment">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/text_margin"
+        android:text="@string/home_scroll_content_placeholder_text" />
+
+</FrameLayout>

--- a/src/main/res/layout/fragment_home_scrolling.xml
+++ b/src/main/res/layout/fragment_home_scrolling.xml
@@ -1,13 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/home_fragment_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".HomeScrollingFragment">
+    tools:context=".HomeScrollingFragment"
+    android:orientation="vertical"
+    >
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/text_margin"
-        android:text="@string/large_text" />
-</android.support.v4.widget.NestedScrollView>
+        android:text="@string/home_header_placeholder_text"
+        android:background="@color/teal_200"
+        android:textSize="10sp"/>
+
+    <FrameLayout
+        android:id="@+id/home_sticky_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/light_blue_A200"
+        />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="false"
+        >
+        <FrameLayout
+            android:id="@+id/home_scroll_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            />
+
+    </ScrollView>
+
+    <FrameLayout
+        android:id="@+id/home_compensation_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/purple_200"
+        />
+
+</LinearLayout>
+

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -25,23 +25,30 @@
     <string name="title_activity_loading_fullscreen">VA Math Calculator</string>
     <string name="dummy_content">LOGO\nGOES\nHERE</string>
     <string name="main_logo_desc">The main app logo displayed on a logo screen.</string>
-    <string name="large_text">
-        <b>HOME PAGE</b>\n\n
 
-        This page will contain a fixed "Dependency Status" box at the top.\n\n
+    <string name="home_header_placeholder_text">
+        <b>HOME PAGE</b>\n
+
+        This page will contain a fixed "Dependency Status" box at the top.\n
 
         Below that will be a scrollable area containing a separate box for each
         individual disability. Add/Edit/Remove buttons will be available on each box to update the
-        settings.\n\n
+        settings. If there orientation is in landscape mode, the fragments will sit horizontally
+        instead of vertically.\n
 
-        See below for example.\n\n
+        See below for example.
+    </string>
+
+    <string name="home_sticky_content_placeholder_text">
         #########################################################\n
         Dependency Status\n
         [ Spouse: 1 ] [ Children Under 18: 3 ]\n
         [ Dependent Parents: 2] [ Daily Aid required: Yes ]\n
         [ # Children with Disabilities: 0 ]\n
         Add | Edit | Delete\n
-        ##########################################################\n\n\n
+        ##########################################################
+    </string>
+    <string name="home_scroll_content_placeholder_text">
         #########################################################\n
         Disability #1 : Short Description\n
 
@@ -61,7 +68,8 @@
         ( isBasic or isSMC ) | Rating | (ifBasic: isBilateral)\n
         Edit | Delete\n
         ##########################################################\n\n\n
-
+    </string>
+    <string name="home_compensation_content_placeholder_text">
         ________________________________________________
         Combined Disability Rating: DISABILITY RATING\n
         SCM Rating (if any): SCM STATUS\n


### PR DESCRIPTION
The main fragment_home_scrolling.xml layout is upgraded to include
different FragmentLayout sections. These sections will load the
different child fragments are used to create the Home page.

Using this approach makes it easier to have different layouts with
different screen orientations, by simply reusing the child fragments
that make up the whole interface.

The placeholder strings have been updated.

TODO: Add actual views to the different child fragments to make a real
interface.
