### PR TITLE
Fixed jerky compensation calculation.

### DIFF
--- a/src/main/java/com/nof/vamathcalculator/FragmentHome_CompensationSummaryFragment_Reward.java
+++ b/src/main/java/com/nof/vamathcalculator/FragmentHome_CompensationSummaryFragment_Reward.java
@@ -48,6 +48,10 @@ public class FragmentHome_CompensationSummaryFragment_Reward extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         reward_text = view.findViewById(R.id.fragment_compensation_summary_reward_text);
+        double compensation = data.getFullCompensation();
+        if(compensation > 0.0) {
+            reward_text.setText(String.format("$ %.2f", compensation));
+        }
     }
 
     @Override


### PR DESCRIPTION
The compensation value would load after the home page became visibile.
This commit makes sure the compensation rate is loaded before the page
is displayed.
